### PR TITLE
feat: persist acceleration and session keepalive

### DIFF
--- a/DNA-Shield.meta.js
+++ b/DNA-Shield.meta.js
@@ -1,41 +1,24 @@
 // ==UserScript==
-// @name		DNA Shield
-// @namespace	DNA Shield
-// @version		13.1
-// @author		Last Roze
-// @description	Dominion With Domination
-// @copyright	©2021 - 2025 // Yoga Budiman
-// @homepage	https://github.com/LastRoze/
-// @homepageURL	https://github.com/LastRoze/
-// @website		https://lastroze.github.io/
-// @source		https://github.com/LastRoze/DNA-Shield
-// @icon		https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @iconURL		https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @defaulticon	https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @icon64		https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @icon64URL	https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @updateURL	https://github.com/LastRoze/DNA-Shield/raw/master/DNA-Shield.meta.js
-// @downloadURL	https://github.com/LastRoze/DNA-Shield/raw/master/DNA-Shield.user.js
-// @supportURL	https://lastroze.github.io/
-// @match		*://*/*
-// @connect		*
-// @run-at		document-start
-// @grant		GM_addStyle
-// @grant		GM_deleteValue
-// @grant		GM_download
-// @grant		GM_getResourceText
-// @grant		GM_getResourceURL
-// @grant		GM_getValue
-// @grant		GM_listValues
-// @grant		GM_notification
-// @grant		GM_openInTab
-// @grant		GM_registerMenuCommand
-// @grant		GM_setClipboard
-// @grant		GM_setValue
-// @grant		GM_unregisterMenuCommand
-// @grant		GM_xmlhttpRequest
-// @grant		unsafeWindow
-// @grant		window.close
-// @grant		window.focus
-// @grant		window.onurlchange
+// @name                DNA Shield
+// @namespace           DNA Shield
+// @version             1.1
+// @author              Last Roze
+// @description         Dominion With Domination
+// @copyright           ©2021 - 2025 // Yoga Budiman
+// @homepage            https://github.com/LastRoze/
+// @homepageURL         https://github.com/LastRoze/
+// @website             https://lastroze.github.io/
+// @source              https://github.com/LastRoze/DNA-Shield
+// @icon                https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @iconURL             https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @defaulticon         https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @icon64              https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @icon64URL           https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @updateURL           https://github.com/LastRoze/DNA-Shield/raw/master/DNA-Shield.meta.js
+// @downloadURL         https://github.com/LastRoze/DNA-Shield/raw/master/DNA-Shield.user.js
+// @supportURL          https://lastroze.github.io/
+// @match               *://*/*
+// @connect             *
+// @run-at              document-start
+// @grant               none
 // ==/UserScript==

--- a/DNA-Shield.user.js
+++ b/DNA-Shield.user.js
@@ -1,42 +1,325 @@
 // ==UserScript==
-// @name		DNA Shield
-// @namespace	DNA Shield
-// @version		13.1
-// @author		Last Roze
-// @description	Dominion With Domination
-// @copyright	©2021 - 2025 // Yoga Budiman
-// @homepage	https://github.com/LastRoze/
-// @homepageURL	https://github.com/LastRoze/
-// @website		https://lastroze.github.io/
-// @source		https://github.com/LastRoze/DNA-Shield
-// @icon		https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @iconURL		https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @defaulticon	https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @icon64		https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @icon64URL	https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
-// @updateURL	https://github.com/LastRoze/DNA-Shield/raw/master/DNA-Shield.meta.js
-// @downloadURL	https://github.com/LastRoze/DNA-Shield/raw/master/DNA-Shield.user.js
-// @supportURL	https://lastroze.github.io/
-// @match		*://*/*
-// @connect		*
-// @run-at		document-start
-// @grant		GM_addStyle
-// @grant		GM_deleteValue
-// @grant		GM_download
-// @grant		GM_getResourceText
-// @grant		GM_getResourceURL
-// @grant		GM_getValue
-// @grant		GM_listValues
-// @grant		GM_notification
-// @grant		GM_openInTab
-// @grant		GM_registerMenuCommand
-// @grant		GM_setClipboard
-// @grant		GM_setValue
-// @grant		GM_unregisterMenuCommand
-// @grant		GM_xmlhttpRequest
-// @grant		unsafeWindow
-// @grant		window.close
-// @grant		window.focus
-// @grant		window.onurlchange
+// @name                DNA Shield
+// @namespace           DNA Shield
+// @version             1.1
+// @author              Last Roze
+// @description         Dominion With Domination
+// @copyright           ©2021 - 2025 // Yoga Budiman
+// @homepage            https://github.com/LastRoze/
+// @homepageURL         https://github.com/LastRoze/
+// @website             https://lastroze.github.io/
+// @source              https://github.com/LastRoze/DNA-Shield
+// @icon                https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @iconURL             https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @defaulticon         https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @icon64              https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @icon64URL           https://github.com/LastRoze/DNA-Shield/blob/master/DNA.jpg?raw=true
+// @updateURL           https://github.com/LastRoze/DNA-Shield/raw/master/DNA-Shield.meta.js
+// @downloadURL         https://github.com/LastRoze/DNA-Shield/raw/master/DNA-Shield.user.js
+// @supportURL          https://lastroze.github.io/
+// @match               *://*/*
+// @connect             *
+// @run-at              document-start
+// @grant               none
 // ==/UserScript==
-/* global $, jQuery */
+
+(function dnaShieldUniversal() {
+  "use strict";
+
+  const LAZY_TAGS = new Set(["IMG", "IFRAME"]);
+  const IDLE = window.requestIdleCallback || function fallbackIdle(fn) {
+    return window.setTimeout(() => fn({ didTimeout: false, timeRemaining: () => 50 }), 1);
+  };
+  const CANCEL_IDLE = window.cancelIdleCallback || function fallbackCancel(id) {
+    window.clearTimeout(id);
+  };
+  const KEEPALIVE_INTERVAL = 45000;
+  const MOTION_STYLE_ID = "dna-shield-motion";
+
+  let scheduledScanToken = null;
+  let keepAliveTimer = 0;
+  let navigationHooksInstalled = false;
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bootstrap, { once: true });
+  } else {
+    bootstrap();
+  }
+
+  function bootstrap() {
+    installMotionDampener();
+    optimizeSubtree(document.documentElement);
+    observeMutations();
+    observeNavigation();
+    setupKeepAlive();
+    IDLE(() => scanForLateResources());
+    window.addEventListener("load", scheduleScan, { once: true });
+  }
+
+  function observeMutations() {
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === "childList") {
+          for (const node of mutation.addedNodes) {
+            optimizeNode(node);
+          }
+        } else if (mutation.type === "attributes") {
+          optimizeElement(mutation.target);
+        }
+      }
+    });
+
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["src", "data-src", "loading", "preload", "poster"],
+    });
+  }
+
+  function scanForLateResources() {
+    const selector = "img, iframe, video, audio";
+    const elements = document.querySelectorAll(selector);
+    for (const el of elements) {
+      optimizeElement(el);
+    }
+  }
+
+  function scheduleScan() {
+    if (scheduledScanToken !== null) {
+      CANCEL_IDLE(scheduledScanToken);
+    }
+    scheduledScanToken = IDLE(() => {
+      scheduledScanToken = null;
+      scanForLateResources();
+    });
+  }
+
+  function optimizeSubtree(root) {
+    if (!root || root.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+
+    optimizeElement(root);
+    const selector = "img, iframe, video, audio";
+    const descendants = root.querySelectorAll(selector);
+    for (const el of descendants) {
+      optimizeElement(el);
+    }
+  }
+
+  function optimizeNode(node) {
+    if (!node) return;
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      optimizeSubtree(node);
+    }
+  }
+
+  function optimizeElement(el) {
+    switch (el.tagName) {
+      case "IMG":
+        tuneImage(el);
+        break;
+      case "IFRAME":
+        tuneIframe(el);
+        break;
+      case "VIDEO":
+        tuneVideo(el);
+        break;
+      case "AUDIO":
+        tuneAudio(el);
+        break;
+      default:
+        break;
+    }
+  }
+
+  function installMotionDampener() {
+    if (document.getElementById(MOTION_STYLE_ID)) {
+      return;
+    }
+    const style = document.createElement("style");
+    style.id = MOTION_STYLE_ID;
+    style.textContent = `
+      :root {
+        scroll-behavior: auto !important;
+      }
+      * {
+        animation-duration: 0.001s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0.001s !important;
+        transition-delay: 0s !important;
+      }
+    `;
+    (document.head || document.documentElement).appendChild(style);
+  }
+
+  function tuneImage(img) {
+    if (!img.isConnected) return;
+
+    if (!img.hasAttribute("decoding")) {
+      img.setAttribute("decoding", "async");
+    }
+
+    if (!img.hasAttribute("loading") && shouldLazy(img)) {
+      img.setAttribute("loading", "lazy");
+    }
+  }
+
+  function observeNavigation() {
+    if (navigationHooksInstalled) {
+      return;
+    }
+    navigationHooksInstalled = true;
+
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+
+    function hookNavigation(fn) {
+      return function patchedState() {
+        if (typeof fn === "function") {
+          const outcome = fn.apply(this, arguments);
+          scheduleScan();
+          return outcome;
+        }
+        scheduleScan();
+        return undefined;
+      };
+    }
+
+    if (typeof originalPushState === "function") {
+      history.pushState = hookNavigation(originalPushState);
+    }
+    if (typeof originalReplaceState === "function") {
+      history.replaceState = hookNavigation(originalReplaceState);
+    }
+
+    window.addEventListener("popstate", scheduleScan);
+    window.addEventListener("pageshow", scheduleScan);
+  }
+
+  function setupKeepAlive() {
+    const canPing = typeof navigator !== "undefined" && (typeof navigator.sendBeacon === "function" || typeof window.fetch === "function");
+    if (!canPing) {
+      return;
+    }
+
+    const sendKeepAlive = () => {
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+      const target = buildKeepAliveURL();
+      
+      if (typeof navigator.sendBeacon === "function") {
+        try {
+          const payload = typeof Blob === "function" ? new Blob([""], { type: "text/plain" }) : "";
+          navigator.sendBeacon(target, payload);
+          return;
+        } catch (error) {
+          // Fallback to fetch when sendBeacon fails.
+        }
+      }
+
+      if (typeof window.fetch === "function") {
+        try {
+          window.fetch(target, {
+            method: "GET",
+            mode: "no-cors",
+            cache: "no-store",
+            keepalive: true,
+          }).catch(() => {});
+        } catch (error) {
+          // Swallow errors silently to remain non-intrusive.
+        }
+      }
+    };
+
+    sendKeepAlive();
+    keepAliveTimer = window.setInterval(sendKeepAlive, KEEPALIVE_INTERVAL);
+
+    const teardown = () => {
+      if (keepAliveTimer) {
+        window.clearInterval(keepAliveTimer);
+        keepAliveTimer = 0;
+      }
+    };
+
+    window.addEventListener("pagehide", teardown, { once: true });
+    window.addEventListener("beforeunload", teardown, { once: true });
+  }
+
+  function buildKeepAliveURL() {
+    if (typeof URL !== "function") {
+      return window.location.href;
+    }
+    const url = new URL(window.location.href);
+    url.searchParams.set("dna-shield-keepalive", Date.now().toString(36));
+    return url.toString();
+  }
+
+  function tuneIframe(iframe) {
+    if (!iframe.isConnected) return;
+
+    if (!iframe.hasAttribute("loading") && shouldLazy(iframe)) {
+      iframe.setAttribute("loading", "lazy");
+    }
+  }
+
+  function tuneVideo(video) {
+    if (!video.isConnected) return;
+
+    if (!video.hasAttribute("preload") && !video.autoplay && !video.hasAttribute("data-dna-keep-preload")) {
+      video.setAttribute("preload", "metadata");
+    }
+
+    if (video.hasAttribute("poster")) {
+      const poster = video.getAttribute("poster");
+      if (poster && !video.dataset.dnaPosterHint) {
+        video.dataset.dnaPosterHint = "1";
+        const img = new Image();
+        img.decoding = "async";
+        img.src = poster;
+      }
+    }
+  }
+
+  function tuneAudio(audio) {
+    if (!audio.isConnected) return;
+
+    if (!audio.hasAttribute("preload") && !audio.autoplay && !audio.hasAttribute("data-dna-keep-preload")) {
+      audio.setAttribute("preload", "metadata");
+    }
+  }
+
+  function shouldLazy(el) {
+    if (!LAZY_TAGS.has(el.tagName)) {
+      return false;
+    }
+
+    if (el.hasAttribute("loading")) {
+      return el.getAttribute("loading") === "lazy";
+    }
+
+    if (!isConnectedAndVisible(el)) {
+      return true;
+    }
+
+    const rect = el.getBoundingClientRect();
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const verticalThreshold = viewportHeight * 1.2 + 200;
+    const horizontalThreshold = viewportWidth * 1.2 + 200;
+
+    const verticallyCritical = rect.top < verticalThreshold && rect.bottom > -200;
+    const horizontallyCritical = rect.left < horizontalThreshold && rect.right > -200;
+
+    return !(verticallyCritical && horizontallyCritical);
+  }
+
+  function isConnectedAndVisible(el) {
+    if (!el.isConnected) return false;
+    if (typeof el.getClientRects !== "function") return false;
+    const rects = el.getClientRects();
+    return rects.length > 0;
+  }
+})();

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # DNA-Shield
+
 Dominion With Domination
+
+## Features
+
+- Automatically hints browsers to decode images asynchronously and lazily load offscreen media for faster first paint.
+- Applies native lazy-loading to newly added images and iframes while respecting critical above-the-fold content.
+- Dampens animations and transitions at the CSS level so interfaces snap into place without altering layouts.
+- Light-touch media tuning that limits video and audio preloading to metadata unless explicitly required by the site.
+- Keeps optimizations active across navigation events and single-page-app route changes without configuration.
+- Sends low-overhead keepalive pings so sites treat the session as active without simulating user movement.
+- Runs on every site without menus, overlays, or per-domain configuration so the acceleration feels native.
+
+## Usage
+
+1. Install `DNA-Shield.user.js` in Tampermonkey.
+2. Browse normally—the optimizations apply automatically on every page.
+
+## Versioning
+
+DNA Shield follows a simple major.minor progression that starts at `1.0`, increments the minor portion through `1.9`, then advances to the next major release (for example `2.0`).


### PR DESCRIPTION
## Summary
- cut the release line back to 1.1 and document the major.minor progression that advances after 1.9
- inject a universal motion dampener, keep history-aware scans alive through SPA navigations, and rescan once the page finishes loading
- add network-level keepalive pings so sites keep the session warm without introducing UI chrome

## Testing
- node --check DNA-Shield.user.js

------
https://chatgpt.com/codex/tasks/task_e_68cbcbc2deb0832482b07973e98de40c