### PR TITLE
Refine motion dampening heuristics

### DIFF
--- a/DNA-Shield.meta.js
+++ b/DNA-Shield.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name                DNA Shield
 // @namespace           DNA Shield
-// @version             1.1
+// @version             1.2
 // @author              Last Roze
 // @description         Dominion With Domination
 // @copyright           ©2021 - 2025 // Yoga Budiman

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dominion With Domination
 
 - Automatically hints browsers to decode images asynchronously and lazily load offscreen media for faster first paint.
 - Applies native lazy-loading to newly added images and iframes while respecting critical above-the-fold content.
-- Dampens animations and transitions at the CSS level so interfaces snap into place without altering layouts.
+- Dampens excessive animations and transitions by clamping their run time while allowing critical or repeated motion to continue normally. Developers can opt a subtree out by adding a `data-dna-keep-motion` attribute.
 - Light-touch media tuning that limits video and audio preloading to metadata unless explicitly required by the site.
 - Keeps optimizations active across navigation events and single-page-app route changes without configuration.
 - Sends low-overhead keepalive pings so sites treat the session as active without simulating user movement.


### PR DESCRIPTION
## Summary
- replace the blanket animation override with event-driven clamping that keeps motion responsive while avoiding layout glitches
- add time parsing helpers and respect data-dna-keep-motion opt-outs so sites can keep critical motion intact
- document the new behavior and bump the userscript metadata version

## Testing
- node --check DNA-Shield.user.js

------
https://chatgpt.com/codex/tasks/task_e_68cc102c627c8324873d9ee413d87ba3