### PR TITLE
Improve resource prioritization and keepalive

### DIFF
--- a/DNA-Shield.meta.js
+++ b/DNA-Shield.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name                DNA Shield
 // @namespace           DNA Shield
-// @version             1.2
+// @version             1.3
 // @author              Last Roze
 // @description         Dominion With Domination
 // @copyright           ©2021 - 2025 // Yoga Budiman

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Dominion With Domination
 ## Features
 
 - Automatically hints browsers to decode images asynchronously and lazily load offscreen media for faster first paint.
+- Applies modern priority hints so above-the-fold images and iframes stream early while pushing offscreen requests into the background.
 - Applies native lazy-loading to newly added images and iframes while respecting critical above-the-fold content.
 - Dampens excessive animations and transitions by clamping their run time while allowing critical or repeated motion to continue normally. Developers can opt a subtree out by adding a `data-dna-keep-motion` attribute.
 - Light-touch media tuning that limits video and audio preloading to metadata unless explicitly required by the site.


### PR DESCRIPTION
## Summary
- add fetch priority hints and compatibility attributes so critical images/iframes stream sooner while offscreen ones stay lazy
- tighten the lazy-loading heuristics and reuse them for priority decisions without adding any UI
- harden the keepalive routine with multiple transport fallbacks and adaptive timing so anti-idle pings stay active on every site
- document the new priority hint behaviour in the README

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc136cd15c83248f48d7e04bc0369e