### PR TITLE
Improve keepalive resilience

### DIFF
--- a/DNA-Shield.meta.js
+++ b/DNA-Shield.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name                DNA Shield
 // @namespace           DNA Shield
-// @version             1.3
+// @version             1.4
 // @author              Last Roze
 // @description         Dominion With Domination
 // @copyright           ©2021 - 2025 // Yoga Budiman


### PR DESCRIPTION
## Summary
- harden the keepalive routine with request deduplication, online detection, and resilient fallbacks
- restart timers safely around visibility, focus, and connectivity changes to avoid unwanted reloads
- bump the userscript metadata version to reflect the keepalive reliability improvements

## Testing
- node --check DNA-Shield.user.js

------
https://chatgpt.com/codex/tasks/task_e_68d0bb0dcd90832490dc21d8684d12e0