### PR TITLE
Accelerate animations and visibility for DNA Shield 1.6

### DIFF
--- a/DNA-Shield.meta.js
+++ b/DNA-Shield.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name                DNA Shield
 // @namespace           DNA Shield
-// @version             1.4
+// @version             1.6
 // @author              Last Roze
 // @description         Dominion With Domination
 // @copyright           ©2021 - 2025 // Yoga Budiman


### PR DESCRIPTION
## Summary
- bump the published script metadata to version 1.6
- enforce global motion clamps, remove async-hide delays, and harden root styles for faster paint
- patch Web Animations API calls to respect the new timing ceilings without throwing errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0be3d95cc83249445f72db27763b5