### PR TITLE
Eliminate visual delays and rename motion opt-out

### DIFF
--- a/DNA-Shield.user.js
+++ b/DNA-Shield.user.js
@@ -39,9 +39,10 @@
   const MOTION_STYLE_ID = "dna-shield-motion";
   const MAX_TRANSITION_DURATION = 140;
   const MAX_ANIMATION_DURATION = 180;
-  const MAX_MOTION_DELAY = 60;
-  const GLOBAL_MOTION_DELAY = Math.min(45, MAX_MOTION_DELAY);
-  const MOTION_TIMING_FUNCTION = "step-end";
+  const MAX_MOTION_DELAY = 0;
+  const GLOBAL_MOTION_DELAY = 0;
+  const MOTION_TIMING_FUNCTION = "linear";
+  const MOTION_OPT_OUT_ATTRIBUTE = "DNA-Shield";
   const ROOT_STYLE_OVERRIDES = [
     ["scroll-behavior", "auto"],
     ["animation-duration", `${MAX_ANIMATION_DURATION}ms`],
@@ -170,14 +171,15 @@
     const animationDuration = formatTime(MAX_ANIMATION_DURATION);
     const transitionDuration = formatTime(MAX_TRANSITION_DURATION);
     const motionDelay = formatTime(GLOBAL_MOTION_DELAY);
+    const optOutSelector = `[${MOTION_OPT_OUT_ATTRIBUTE}]`;
     style.textContent = `
       :root {
         scroll-behavior: auto !important;
       }
 
-      :root :where(*:not([data-dna-keep-motion])),
-      :root :where(*:not([data-dna-keep-motion]))::before,
-      :root :where(*:not([data-dna-keep-motion]))::after {
+      :root :where(*:not(${optOutSelector})),
+      :root :where(*:not(${optOutSelector}))::before,
+      :root :where(*:not(${optOutSelector}))::after {
         animation-duration: ${animationDuration} !important;
         -webkit-animation-duration: ${animationDuration} !important;
         animation-delay: ${motionDelay} !important;
@@ -193,12 +195,12 @@
         scroll-behavior: auto !important;
       }
 
-      [data-dna-keep-motion],
-      [data-dna-keep-motion]::before,
-      [data-dna-keep-motion]::after,
-      [data-dna-keep-motion] :where(*),
-      [data-dna-keep-motion] :where(*)::before,
-      [data-dna-keep-motion] :where(*)::after {
+      ${optOutSelector},
+      ${optOutSelector}::before,
+      ${optOutSelector}::after,
+      ${optOutSelector} :where(*),
+      ${optOutSelector} :where(*)::before,
+      ${optOutSelector} :where(*)::after {
         animation-duration: revert !important;
         -webkit-animation-duration: revert !important;
         animation-delay: revert !important;
@@ -589,7 +591,7 @@
       return;
     }
 
-    if (typeof target.closest === "function" && target.closest("[data-dna-keep-motion]")) {
+    if (typeof target.closest === "function" && target.closest(`[${MOTION_OPT_OUT_ATTRIBUTE}]`)) {
       return;
     }
 
@@ -615,7 +617,7 @@
       return;
     }
 
-    if (typeof target.closest === "function" && target.closest("[data-dna-keep-motion]")) {
+    if (typeof target.closest === "function" && target.closest(`[${MOTION_OPT_OUT_ATTRIBUTE}]`)) {
       return;
     }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Dominion With Domination
 - Automatically hints browsers to decode images asynchronously and lazily load offscreen media for faster first paint.
 - Applies modern priority hints so above-the-fold images and iframes stream early while pushing offscreen requests into the background.
 - Applies native lazy-loading to newly added images and iframes while respecting critical above-the-fold content.
-- Dampens excessive animations and transitions by clamping their run time while allowing critical or repeated motion to continue normally. Developers can opt a subtree out by adding a `data-dna-keep-motion` attribute.
+- Dampens excessive animations and transitions by clamping their run time while allowing critical or repeated motion to continue normally. Developers can opt a subtree out by adding a `DNA-Shield` attribute.
 - Light-touch media tuning that limits video and audio preloading to metadata unless explicitly required by the site.
 - Keeps optimizations active across navigation events and single-page-app route changes without configuration.
 - Sends low-overhead keepalive pings so sites treat the session as active without simulating user movement.

--- a/__tests__/dna-shield.test.js
+++ b/__tests__/dna-shield.test.js
@@ -58,7 +58,7 @@ describe("DNA Shield internals", () => {
 
   test("clampDelays enforces motion delay limit", () => {
     const result = internals.clampDelays([0, 10, 1000]);
-    expect(result.values).toEqual([0, 10, 60]);
+    expect(result.values).toEqual([0, 0, 0]);
     expect(result.changed).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- remove imposed motion delays by switching to linear timing with zero wait and add a reusable DNA-Shield opt-out selector
- update the injected stylesheet and animation guards to honor the new attribute and avoid delayed hover reactions
- refresh documentation and unit tests to describe the DNA-Shield opt-out and immediate delay clamping

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0ccb28c908324afea654904cec55f