### PR TITLE
Improve lazy-loading heuristics and bump version to 1.7

### DIFF
--- a/DNA-Shield.meta.js
+++ b/DNA-Shield.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name                DNA Shield
 // @namespace           DNA Shield
-// @version             1.6
+// @version             1.7
 // @author              Last Roze
 // @description         Dominion With Domination
 // @copyright           ©2021 - 2025 // Yoga Budiman


### PR DESCRIPTION
## Summary
- refine the image and iframe tuning pipeline to defer lazy decisions until layout is stable and remove unwanted placeholders
- introduce animation frame-backed retries with hidden-element detection to keep priority hints accurate without flashes
- bump the userscript metadata version to 1.7

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0cf0589a0832489c7656c3cf43c73