### PR TITLE
Remove lazy loading support and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,7 @@
 - Prefer small, focused helper functions and keep changes backwards compatible with the userscript runtime.
 - When adding tests, use Jest with the jsdom environment and expose internal helpers through a guarded global for test access when necessary.
 - Always run `npm test` before completing work.
+
+## Versioning
+
+DNA Shield follows a simple major.minor progression that starts at `1.0`, increments the minor portion through `1.9`, then advances to the next major release (for example `2.0`).

--- a/DNA-Shield.meta.js
+++ b/DNA-Shield.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name                DNA Shield
 // @namespace           DNA Shield
-// @version             1.7
+// @version             1.8
 // @author              Last Roze
 // @description         Dominion With Domination
 // @copyright           ©2021 - 2025 // Yoga Budiman

--- a/DNA-Shield.user.js
+++ b/DNA-Shield.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name                DNA Shield
 // @namespace           DNA Shield
-// @version             1.7
+// @version             1.8
 // @author              Last Roze
 // @description         Dominion With Domination
 // @copyright           ©2021 - 2025 // Yoga Budiman
@@ -26,8 +26,6 @@
 (function dnaShieldUniversal() {
   "use strict";
 
-  const LAZY_TAGS = new Set(["IMG", "IFRAME"]);
-  const ENABLE_LAZY_LOADING_OVERRIDE = false;
   const PRIORITY_COMPAT_ATTRIBUTE = "importance";
   const IDLE = window.requestIdleCallback || function fallbackIdle(fn) {
     return window.setTimeout(() => fn({ didTimeout: false, timeRemaining: () => 50 }), 1);
@@ -67,9 +65,6 @@
   let keepAliveTimer = 0;
   let navigationHooksInstalled = false;
   let keepAliveInFlight = false;
-  const pendingLazyEvaluations = new WeakSet();
-  const lazyEvaluationAttempts = new WeakMap();
-  const managedLazyAttributes = new WeakSet();
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", bootstrap, { once: true });
@@ -108,7 +103,7 @@
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ["src", "data-src", "loading", "preload", "poster"],
+      attributeFilter: ["src", "data-src", "preload", "poster"],
     });
   }
 
@@ -793,10 +788,6 @@
     if (!img.hasAttribute("decoding")) {
       img.setAttribute("decoding", "async");
     }
-
-    if (ENABLE_LAZY_LOADING_OVERRIDE) {
-      applyLazyStrategy(img);
-    }
   }
 
   function observeNavigation() {
@@ -970,10 +961,6 @@
    */
   function tuneIframe(iframe) {
     if (!iframe.isConnected) return;
-
-    if (ENABLE_LAZY_LOADING_OVERRIDE) {
-      applyLazyStrategy(iframe);
-    }
   }
 
   /**
@@ -1010,200 +997,6 @@
     if (!audio.hasAttribute("preload") && !audio.autoplay && !audio.hasAttribute("data-dna-keep-preload")) {
       audio.setAttribute("preload", "metadata");
     }
-  }
-
-  /**
-   * Applies lazy-loading preferences with retry support for uncertain layout states.
-   * When lazy-loading overrides are disabled, this function becomes a no-op.
-   * @param {Element} el - Target media element.
-   * @returns {void}
-   */
-  function applyLazyStrategy(el) {
-    if (!ENABLE_LAZY_LOADING_OVERRIDE) {
-      return;
-    }
-
-    if (!el || !LAZY_TAGS.has(el.tagName)) {
-      return;
-    }
-
-    const decision = computeLazyDecision(el);
-
-    if (decision === "lazy") {
-      lazyEvaluationAttempts.delete(el);
-      if (!el.hasAttribute("loading")) {
-        try {
-          el.setAttribute("loading", "lazy");
-          managedLazyAttributes.add(el);
-        } catch (error) {
-          // Ignore attribute assignment issues to remain resilient.
-        }
-      }
-      applyPriorityHints(el, "low");
-      return;
-    }
-
-    if (decision === "eager") {
-      lazyEvaluationAttempts.delete(el);
-      if (managedLazyAttributes.has(el)) {
-        try {
-          if (el.getAttribute("loading") === "lazy") {
-            el.removeAttribute("loading");
-          }
-        } catch (error) {
-          // Silently ignore removal failures caused by locked attributes.
-        }
-        managedLazyAttributes.delete(el);
-      }
-      applyPriorityHints(el, "high");
-      return;
-    }
-
-    const attempts = lazyEvaluationAttempts.get(el) || 0;
-    if (attempts >= 2) {
-      lazyEvaluationAttempts.delete(el);
-      if (managedLazyAttributes.has(el)) {
-        try {
-          if (el.getAttribute("loading") === "lazy") {
-            el.removeAttribute("loading");
-          }
-        } catch (error) {
-          // Ignore failures and continue with eager hints.
-        }
-        managedLazyAttributes.delete(el);
-      }
-      applyPriorityHints(el, "high");
-      return;
-    }
-
-    lazyEvaluationAttempts.set(el, attempts + 1);
-    scheduleLazyEvaluation(el);
-  }
-
-  /**
-   * Calculates the ideal lazy-loading decision for a media element.
-   * @param {Element} el - Element to inspect.
-   * @returns {"lazy"|"eager"|"defer"} Lazy-loading state decision.
-   */
-  function computeLazyDecision(el) {
-    if (!el || !LAZY_TAGS.has(el.tagName)) {
-      return "eager";
-    }
-
-    if (el.hasAttribute("loading")) {
-      return el.getAttribute("loading") === "lazy" ? "lazy" : "eager";
-    }
-
-    if (!el.isConnected) {
-      return "lazy";
-    }
-
-    if (!hasUsableLayout(el)) {
-      return isEffectivelyHidden(el) ? "lazy" : "defer";
-    }
-
-    let rect;
-    try {
-      rect = el.getBoundingClientRect();
-    } catch (error) {
-      return "defer";
-    }
-
-    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
-    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
-    const verticalThreshold = viewportHeight * 1.1 + 160;
-    const horizontalThreshold = viewportWidth * 1.1 + 160;
-
-    const verticallyCritical = rect.top < verticalThreshold && rect.bottom > -200;
-    const horizontallyCritical = rect.left < horizontalThreshold && rect.right > -200;
-
-    return verticallyCritical && horizontallyCritical ? "eager" : "lazy";
-  }
-
-  /**
-   * Defers a lazy-loading evaluation until the next animation frame.
-   * @param {Element} el - Element scheduled for reevaluation.
-   * @returns {void}
-   */
-  function scheduleLazyEvaluation(el) {
-    if (!el || pendingLazyEvaluations.has(el)) {
-      return;
-    }
-
-    pendingLazyEvaluations.add(el);
-    RAF(() => {
-      pendingLazyEvaluations.delete(el);
-      if (!el.isConnected) {
-        lazyEvaluationAttempts.delete(el);
-        managedLazyAttributes.delete(el);
-        return;
-      }
-      applyLazyStrategy(el);
-    });
-  }
-
-  /**
-   * Determines whether an element currently exposes usable layout metrics.
-   * @param {Element} el - Element to evaluate.
-   * @returns {boolean} True when measurable layout boxes exist.
-   */
-  function hasUsableLayout(el) {
-    if (!el || typeof el.getClientRects !== "function") {
-      return false;
-    }
-
-    let rects;
-    try {
-      rects = el.getClientRects();
-    } catch (error) {
-      return false;
-    }
-
-    if (!rects || rects.length === 0) {
-      return false;
-    }
-
-    for (let index = 0; index < rects.length; index += 1) {
-      const rect = rects[index];
-      if (rect && rect.width > 0 && rect.height > 0) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * Checks if an element appears hidden via CSS styles.
-   * @param {Element} el - Element to check for visibility overrides.
-   * @returns {boolean} True when the element is intentionally hidden.
-   */
-  function isEffectivelyHidden(el) {
-    if (!el || typeof window === "undefined" || typeof window.getComputedStyle !== "function") {
-      return false;
-    }
-
-    let style;
-    try {
-      style = window.getComputedStyle(el);
-    } catch (error) {
-      return false;
-    }
-
-    if (!style) {
-      return false;
-    }
-
-    return style.display === "none" || style.visibility === "hidden";
-  }
-
-  /**
-   * Determines whether an element should be lazily loaded based on viewport heuristics.
-   * @param {Element} el - Element to evaluate for lazy loading.
-   * @returns {boolean} True when the element can be safely deferred.
-   */
-  function shouldLazy(el) {
-    return computeLazyDecision(el) === "lazy";
   }
 
   /**
@@ -1299,8 +1092,6 @@
       clampDelays,
       formatTimeList,
       formatTime,
-      computeLazyDecision,
-      shouldLazy,
       applyPriorityHints,
       getKeepAliveInterval,
       restartKeepAliveTimer,

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Dominion With Domination
 
 ## Features
 
-- Automatically hints browsers to decode images asynchronously and lazily load offscreen media for faster first paint.
-- Applies modern priority hints so above-the-fold images and iframes stream early while pushing offscreen requests into the background.
-- Applies native lazy-loading to newly added images and iframes while respecting critical above-the-fold content.
+- Automatically hints browsers to decode images asynchronously for faster first paint.
+- Applies modern priority hints so above-the-fold images and iframes stream early without extra configuration.
 - Dampens excessive animations and transitions by clamping their run time while allowing critical or repeated motion to continue normally. Developers can opt a subtree out by adding a `DNA-Shield` attribute.
 - Light-touch media tuning that limits video and audio preloading to metadata unless explicitly required by the site.
 - Keeps optimizations active across navigation events and single-page-app route changes without configuration.
@@ -17,7 +16,3 @@ Dominion With Domination
 
 1. Install `DNA-Shield.user.js` in Tampermonkey.
 2. Browse normally—the optimizations apply automatically on every page.
-
-## Versioning
-
-DNA Shield follows a simple major.minor progression that starts at `1.0`, increments the minor portion through `1.9`, then advances to the next major release (for example `2.0`).

--- a/__tests__/dna-shield.test.js
+++ b/__tests__/dna-shield.test.js
@@ -33,7 +33,6 @@ describe("DNA Shield internals", () => {
     expect(internals).toMatchObject({
       parseTimeList: expect.any(Function),
       clampAnimationDurations: expect.any(Function),
-      shouldLazy: expect.any(Function),
       applyPriorityHints: expect.any(Function),
       getKeepAliveInterval: expect.any(Function),
       isOnline: expect.any(Function),
@@ -64,22 +63,6 @@ describe("DNA Shield internals", () => {
 
   test("formatTimeList produces CSS-compatible values", () => {
     expect(internals.formatTimeList([100, 10.5])).toBe("100ms, 10.50ms");
-  });
-
-  test("shouldLazy returns false for critical elements and true for distant ones", () => {
-    const critical = document.createElement("img");
-    document.body.appendChild(critical);
-    critical.getClientRects = () => [{ width: 10, height: 10 }];
-    critical.getBoundingClientRect = () => ({ top: 10, bottom: 60, left: 10, right: 60 });
-
-    expect(internals.shouldLazy(critical)).toBe(false);
-
-    const distant = document.createElement("img");
-    document.body.appendChild(distant);
-    distant.getClientRects = () => [{ width: 10, height: 10 }];
-    distant.getBoundingClientRect = () => ({ top: 4000, bottom: 4100, left: 3000, right: 3100 });
-
-    expect(internals.shouldLazy(distant)).toBe(true);
   });
 
   test("applyPriorityHints sets attribute fallbacks", () => {


### PR DESCRIPTION
## Summary
- remove lazy loading overrides from the userscript now that lazy loading is no longer supported
- bump the published script metadata and refresh the README to reflect the streamlined feature set
- relocate the versioning guidance into AGENTS.md and update the test suite accordingly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0d2b6d6008324a4e89472a1c70983